### PR TITLE
Raise runtime error when module is not available

### DIFF
--- a/lib/proto_response.ex
+++ b/lib/proto_response.ex
@@ -28,14 +28,8 @@ defmodule ProtoResponse do
   def proto_response(conn, code, proto) do
     response = Phoenix.ConnTest.response(conn, code)
 
-    case Plug.Conn.get_resp_header(conn, "content-type") |> List.first do
-      "application/x-protobuf" <> _ ->
-        :ok
-      nil ->
-        raise RuntimeError, message: "no content-type was set, expected a protobuf response"
-      other ->
-        raise RuntimeError, message: "expected content-type for protobuf, got: \"#{other}\""
-    end
+    ensure_content_type_or_raise!(conn)
+    ensure_module_available_or_raise!(proto)
 
     try do
       %{__struct__: ^proto} = response |> proto.decode()
@@ -44,4 +38,26 @@ defmodule ProtoResponse do
         raise RuntimeError, message: "could not decode Protobuf body"
     end
   end
+
+  defp ensure_content_type_or_raise!(conn) do
+    case Plug.Conn.get_resp_header(conn, "content-type") |> List.first do
+      "application/x-protobuf" <> _ ->
+        :ok
+      nil ->
+        raise RuntimeError, message: "no content-type was set, expected a protobuf response"
+      other ->
+        raise RuntimeError, message: "expected content-type for protobuf, got: \"#{other}\""
+    end
+  end
+
+  defp ensure_module_available_or_raise!(proto_module) do
+    case Code.ensure_loaded(proto_module) do
+      {:module, ^proto_module} -> :ok
+      {:error, _} ->
+        raise RuntimeError, message: "module #{module_name(proto_module)} is not available"
+    end
+  end
+
+  defp module_name(module),
+    do: module |> to_string |> String.replace(~r/^Elixir\./, "")
 end

--- a/test/proto_response_test.exs
+++ b/test/proto_response_test.exs
@@ -54,6 +54,17 @@ defmodule ProtoResponseTest do
     )
   end
 
+  test "raise response module doesn't exist" do
+    resp = Proto.M.new(text: "test") |> Proto.M.encode()
+    conn = build_conn() |> put_resp_content_type("application/x-protobuf") |> send_resp(200, resp)
+
+    assert_raise(
+      RuntimeError,
+      "module Proto.Missing is not available",
+      fn -> proto_response(conn, 200, Proto.Missing) end
+    )
+  end
+
   test "checks status code before headers" do
     conn = build_conn() |> send_resp(400, "")
 


### PR DESCRIPTION
Raise with a helpful message when the module is not available instead of raising with misleading `"could not decode Protobuf body"` message